### PR TITLE
fix: ensure rcc version is less than 6.0.0

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,10 +8,18 @@ build:
 
 compile:
   #!/usr/bin/env bash
+  rcc_version=$(rcc --version)
+  rcc_major=$(echo $rcc_version | awk '{split($2, a, "."); print a[1]}')
+  if [ "$rcc_major" -gt 5 ]; then
+    echo "rcc version must be less than 6.0.0"
+    exit 1
+  fi
+  echo "Compiling theme using $rcc_version"
+
   rm -rf dist
   mkdir dist
   for flavor in $(whiskers --list-flavors -o plain); do
-    /usr/lib/qt6/libexec/rcc src/catppuccin-${flavor}/resources.qrc -o dist/catppuccin-${flavor}.qbtheme -binary
+    rcc src/catppuccin-${flavor}/resources.qrc -o dist/catppuccin-${flavor}.qbtheme -binary
   done
 
 package: build compile


### PR DESCRIPTION
This should ensure that the theme works across both Linux and Windows.
