### PR TITLE
fix: make selection visible in text dialogs

### DIFF
--- a/src/catppuccin-frappe/stylesheet.qss
+++ b/src/catppuccin-frappe/stylesheet.qss
@@ -11,7 +11,7 @@
 QWidget {
   background-color: #292c3c;
   color: #c6d0f5;
-  selection-background-color: #44495d;
+  selection-background-color: #626880;
   selection-color: #c6d0f5;
 }
 

--- a/src/catppuccin-latte/stylesheet.qss
+++ b/src/catppuccin-latte/stylesheet.qss
@@ -11,7 +11,7 @@
 QWidget {
   background-color: #e6e9ef;
   color: #4c4f69;
-  selection-background-color: #d4d7df;
+  selection-background-color: #acb0be;
   selection-color: #4c4f69;
 }
 

--- a/src/catppuccin-macchiato/stylesheet.qss
+++ b/src/catppuccin-macchiato/stylesheet.qss
@@ -11,7 +11,7 @@
 QWidget {
   background-color: #1e2030;
   color: #cad3f5;
-  selection-background-color: #3a3d53;
+  selection-background-color: #5b6078;
   selection-color: #cad3f5;
 }
 

--- a/src/catppuccin-mocha/stylesheet.qss
+++ b/src/catppuccin-mocha/stylesheet.qss
@@ -11,7 +11,7 @@
 QWidget {
   background-color: #181825;
   color: #cdd6f4;
-  selection-background-color: #353649;
+  selection-background-color: #585b70;
   selection-color: #cdd6f4;
 }
 

--- a/templates/stylesheet.tera
+++ b/templates/stylesheet.tera
@@ -19,7 +19,7 @@ whiskers:
 QWidget {
   background-color: {{ mantle.hex }};
   color: {{ text.hex }};
-  selection-background-color: {{ surface2 | mix(color=base, amount=0.4) | get(key="hex")}};
+  selection-background-color: {{ surface2 | mod(opacity=0.3) | get(key="hex")}};
   selection-color: {{ text.hex }};
 }
 


### PR DESCRIPTION
Hello, this little change would fix https://github.com/catppuccin/qbittorrent/issues/22

I looked at the style guide for selection background, so I changed it to surface2 and opacity 30%

Before (text is selected, but you can only barely see it if you zoom in really close):
![qbit_old](https://github.com/user-attachments/assets/471efb90-8482-4e5e-a348-6f22b00dd63f)

Now:
![qbit_new](https://github.com/user-attachments/assets/65860cef-ac69-4456-96c5-0efb1a825b86)
