### PR TITLE
fix: change `stalledUploading` to `blue`

### DIFF
--- a/src/catppuccin-frappe/config.json
+++ b/src/catppuccin-frappe/config.json
@@ -43,7 +43,7 @@
       "TransferList.ForcedDownloadingMetadata": "#99d1db",
       "TransferList.ForcedDownloading": "#a6d189",
       "TransferList.Uploading": "#8caaee",
-      "TransferList.StalledUploading": "#838ba7",
+      "TransferList.StalledUploading": "#8caaee",
       "TransferList.ForcedUploading": "#8caaee",
       "TransferList.QueuedDownloading": "#81c8be",
       "TransferList.QueuedUploading": "#81c8be",

--- a/src/catppuccin-latte/config.json
+++ b/src/catppuccin-latte/config.json
@@ -43,7 +43,7 @@
       "TransferList.ForcedDownloadingMetadata": "#04a5e5",
       "TransferList.ForcedDownloading": "#40a02b",
       "TransferList.Uploading": "#1e66f5",
-      "TransferList.StalledUploading": "#8c8fa1",
+      "TransferList.StalledUploading": "#1e66f5",
       "TransferList.ForcedUploading": "#1e66f5",
       "TransferList.QueuedDownloading": "#179299",
       "TransferList.QueuedUploading": "#179299",

--- a/src/catppuccin-macchiato/config.json
+++ b/src/catppuccin-macchiato/config.json
@@ -43,7 +43,7 @@
       "TransferList.ForcedDownloadingMetadata": "#91d7e3",
       "TransferList.ForcedDownloading": "#a6da95",
       "TransferList.Uploading": "#8aadf4",
-      "TransferList.StalledUploading": "#8087a2",
+      "TransferList.StalledUploading": "#8aadf4",
       "TransferList.ForcedUploading": "#8aadf4",
       "TransferList.QueuedDownloading": "#8bd5ca",
       "TransferList.QueuedUploading": "#8bd5ca",

--- a/src/catppuccin-mocha/config.json
+++ b/src/catppuccin-mocha/config.json
@@ -43,7 +43,7 @@
       "TransferList.ForcedDownloadingMetadata": "#89dceb",
       "TransferList.ForcedDownloading": "#a6e3a1",
       "TransferList.Uploading": "#89b4fa",
-      "TransferList.StalledUploading": "#7f849c",
+      "TransferList.StalledUploading": "#89b4fa",
       "TransferList.ForcedUploading": "#89b4fa",
       "TransferList.QueuedDownloading": "#94e2d5",
       "TransferList.QueuedUploading": "#94e2d5",

--- a/templates/config.tera
+++ b/templates/config.tera
@@ -51,7 +51,7 @@ whiskers:
       "TransferList.ForcedDownloadingMetadata": "{{ sky.hex }}",
       "TransferList.ForcedDownloading": "{{ green.hex }}",
       "TransferList.Uploading": "{{ blue.hex }}",
-      "TransferList.StalledUploading": "{{ overlay1.hex }}",
+      "TransferList.StalledUploading": "{{ blue.hex }}",
       "TransferList.ForcedUploading": "{{ blue.hex }}",
       "TransferList.QueuedDownloading": "{{ teal.hex }}",
       "TransferList.QueuedUploading": "{{ teal.hex }}",


### PR DESCRIPTION
Addresses https://github.com/catppuccin/qbittorrent/issues/27

I think @uselessgithub is right, the color for stalledUploading should be blue as well, like when it's uploading, it's the same way the default theme handles it, since stalledUploading doesn't mean anything is wrong or disabled, just that it is ready to upload but there currently is no peer that wants a piece.

<details>
  <summary>default theme</summary>

![2025-01-24T17:42:09,706248647+01:00](https://github.com/user-attachments/assets/1e918d84-8b9c-4046-af1b-997efe8f48cc)

</details>

<details>
  <summary>old theme</summary>

![2025-01-24T17:41:40,735818713+01:00](https://github.com/user-attachments/assets/0d786197-599d-471b-a0cb-2bd03c390efa)

</details>

<details>
  <summary>new changes</summary>

![2025-01-24T18:23:36,713191116+01:00](https://github.com/user-attachments/assets/960c188c-2a9b-4026-8fec-49eff23bd394)

</details>